### PR TITLE
PLENIGO-765-php-sdk-oauth2-calls-must-go

### DIFF
--- a/src/plenigo/PlenigoManager.php
+++ b/src/plenigo/PlenigoManager.php
@@ -143,6 +143,16 @@ final class PlenigoManager
     }
 
     /**
+     * This returns the URL used by the OAuth API communications within plenigo.
+     *
+     * @return string The API OAuth URL
+     */
+    public function getUrlOAuth()
+    {
+        return $this->config->getUrlOAuth();
+    }
+
+    /**
      * Checks if test mode is active or not.
      *
      * @return bool test mode

--- a/src/plenigo/internal/ApiURLs.php
+++ b/src/plenigo/internal/ApiURLs.php
@@ -23,7 +23,12 @@ final class ApiURLs
     /**
      * Default plenigo URL.
      */
-    const DEFAULT_PLENIGO_URL = "https://www.plenigo.com";
+    const DEFAULT_PLENIGO_URL = "https://api.plenigo.com";
+
+    /**
+     * OAuth2 plenigo URL.
+     */
+    const OAUTH_PLENIGO_URL = "https://www.plenigo.com";
 
     /**
      * This URL is used to check if an user has access to a product.

--- a/src/plenigo/internal/models/Configuration.php
+++ b/src/plenigo/internal/models/Configuration.php
@@ -31,6 +31,11 @@ class Configuration
     private $url;
 
     /**
+     * The URL where Oauth API is located.
+     */
+    private $urlOAuth;
+
+    /**
      * The users secret that will be used with the SDK.
      */
     private $secret;
@@ -52,19 +57,24 @@ class Configuration
      * @param string $companyId the application company ID
      * @param bool   $testMode  specifies the mode of operation
      * @param string $url       the URL to use for communication end-points
+     * @param string $urlOAuth       the URL to use for OAuth API calls
      *
      * @return void
      */
-    public function __construct($secret, $companyId, $testMode = false, $url = null)
+    public function __construct($secret, $companyId, $testMode = false, $url = null, $urlOAuth = null)
     {
         if ($url === null) {
                 $url = ApiURLs::DEFAULT_PLENIGO_URL;
+        }
+        if ($urlOAuth === null) {
+                $urlOAuth = ApiURLs::OAUTH_PLENIGO_URL;
         }
 
         $this->secret = $secret;
         $this->companyId = $companyId;
         $this->testMode = safe_boolval($testMode);
         $this->url = $url;
+        $this->urlOAuth = $urlOAuth;
     }
 
     /**
@@ -85,6 +95,16 @@ class Configuration
     public function getUrl()
     {
         return $this->url;
+    }
+
+    /**
+     * gets the OAuth URL
+     *
+     * @return string the OAuth url
+     */
+    public function getUrlOAuth()
+    {
+        return $this->urlOAuth;
     }
 
     /**

--- a/src/plenigo/internal/services/Service.php
+++ b/src/plenigo/internal/services/Service.php
@@ -53,9 +53,9 @@ class Service
     protected static function getRequest($endPoint, $oauth = false, array $params = array())
     {
         if($oauth){
-            $url = PlenigoManager::get()->getUrl() . $endPoint;
-        }else{
             $url = PlenigoManager::get()->getUrlOAuth() . $endPoint;
+        }else{
+            $url = PlenigoManager::get()->getUrl() . $endPoint;
         }
 
         return RestClient::get($url, $params);
@@ -74,9 +74,9 @@ class Service
     protected static function postRequest($endPoint, $oauth = false, array $params = array())
     {
         if($oauth){
-            $url = PlenigoManager::get()->getUrl() . $endPoint;
-        }else{
             $url = PlenigoManager::get()->getUrlOAuth() . $endPoint;
+        }else{
+            $url = PlenigoManager::get()->getUrl() . $endPoint;
         }
 
         return RestClient::post($url, $params);

--- a/src/plenigo/internal/services/Service.php
+++ b/src/plenigo/internal/services/Service.php
@@ -45,13 +45,18 @@ class Service
      * end-point on the plenigo REST API.
      *
      * @param string $endPoint The REST end-point to access.
+     * @param bool $oauth TRUE if the needed request is going to the OAuth API.
      * @param array  $params   Optional params to pass to the request.
      *
      * @return the request result.
      */
-    protected static function getRequest($endPoint, array $params = array())
+    protected static function getRequest($endPoint, $oauth = false, array $params = array())
     {
-        $url = PlenigoManager::get()->getUrl() . $endPoint;
+        if($oauth){
+            $url = PlenigoManager::get()->getUrl() . $endPoint;
+        }else{
+            $url = PlenigoManager::get()->getUrlOAuth() . $endPoint;
+        }
 
         return RestClient::get($url, $params);
     }
@@ -61,13 +66,18 @@ class Service
      * end-point on the plenigo REST API.
      *
      * @param string $endPoint The REST end-point to access.
+     * @param bool $oauth TRUE if the needed request is going to the OAuth API.
      * @param array  $params   Optional params to pass to the request.
      *
      * @return the request result.
      */
-    protected static function postRequest($endPoint, array $params)
+    protected static function postRequest($endPoint, $oauth = false, array $params = array())
     {
-        $url = PlenigoManager::get()->getUrl() . $endPoint;
+        if($oauth){
+            $url = PlenigoManager::get()->getUrl() . $endPoint;
+        }else{
+            $url = PlenigoManager::get()->getUrlOAuth() . $endPoint;
+        }
 
         return RestClient::post($url, $params);
     }

--- a/src/plenigo/services/ProductService.php
+++ b/src/plenigo/services/ProductService.php
@@ -67,7 +67,7 @@ class ProductService extends Service {
             ApiParams::SECRET => PlenigoManager::get()->getSecret()
         );
 
-        $request = static::getRequest(ApiURLs::GET_PRODUCT . "/" . $productId, $params);
+        $request = static::getRequest(ApiURLs::GET_PRODUCT . "/" . $productId, false, $params);
 
         $prodDataRequest = new static($request);
 
@@ -124,7 +124,7 @@ class ProductService extends Service {
 
         $params = self::configureListParams($pageSize, $lastID);
 
-        $request = static::getRequest(ApiURLs::LIST_PRODUCTS, $params);
+        $request = static::getRequest(ApiURLs::LIST_PRODUCTS, false, $params);
 
         $prodDataRequest = new static($request);
 
@@ -167,7 +167,7 @@ class ProductService extends Service {
             ApiParams::SECRET => PlenigoManager::get()->getSecret()
         );
 
-        $request = static::getRequest(ApiURLs::GET_CATEGORY . "/" . $categoryId, $params);
+        $request = static::getRequest(ApiURLs::GET_CATEGORY . "/" . $categoryId, false, $params);
 
         $categoryDataRequest = new static($request);
 
@@ -223,7 +223,7 @@ class ProductService extends Service {
 
         $params = self::configureListParams($pageSize, $lastID);
 
-        $request = static::getRequest(ApiURLs::LIST_CATEGORIES, $params);
+        $request = static::getRequest(ApiURLs::LIST_CATEGORIES, false, $params);
 
         $catRequest = new static($request);
 

--- a/src/plenigo/services/TokenService.php
+++ b/src/plenigo/services/TokenService.php
@@ -134,7 +134,7 @@ class TokenService extends Service
             $accessUrl = ApiURLs::GET_ACCESS_TOKEN;
         }
 
-        $request = static::postRequest($accessUrl, $verify->getMap());
+        $request = static::postRequest($accessUrl,true, $verify->getMap());
 
         $accessTokenRequest = new static($request, $csrfToken);
 

--- a/src/plenigo/services/UserService.php
+++ b/src/plenigo/services/UserService.php
@@ -18,7 +18,6 @@ require_once __DIR__ . '/../models/ErrorCode.php';
 use \plenigo\PlenigoManager;
 use \plenigo\PlenigoException;
 use \plenigo\internal\ApiURLs;
-use \plenigo\internal\utils\RestClient;
 use \plenigo\models\UserData;
 use \plenigo\internal\services\Service;
 use \plenigo\internal\models\Customer;
@@ -75,7 +74,7 @@ class UserService extends Service
             'token' => $accessToken,
         );
 
-        $request = static::getRequest(ApiURLs::USER_PROFILE, $params);
+        $request = static::getRequest(ApiURLs::USER_PROFILE, false, $params);
 
         $userDataRequest = new static($request);
         try {
@@ -146,7 +145,7 @@ class UserService extends Service
             ApiParams::PRODUCT_ID => $productId,
             ApiParams::TEST_MODE => $testModeText
         );
-        $request = static::getRequest(ApiURLs::USER_PRODUCT_ACCESS, $params);
+        $request = static::getRequest(ApiURLs::USER_PRODUCT_ACCESS, false, $params);
 
         $userDataRequest = new static($request);
         try {
@@ -188,7 +187,7 @@ class UserService extends Service
             ApiParams::COMPANY_ID => PlenigoManager::get()->getCompanyId(),
             ApiParams::SECRET => PlenigoManager::get()->getSecret()
         );
-        $request = static::getRequest(ApiURLs::PAYWALL_STATE, $params);
+        $request = static::getRequest(ApiURLs::PAYWALL_STATE, false, $params);
 
         $userDataRequest = new static($request);
         try {


### PR DESCRIPTION
- Now using the www.plenigo.com endpoint only for OAuth2 calls (compatibility reasons), All other go to api.plenigo.com
