### PR TITLE
add external customer id flag in createLoginToken-function

### DIFF
--- a/src/plenigo/internal/ApiParams.php
+++ b/src/plenigo/internal/ApiParams.php
@@ -167,4 +167,9 @@ class ApiParams extends BasicEnum {
      * The replacement tag for the Voucher ID
      */
     const URL_VOUCHER_ID_TAG = "{VOUCHER_ID}";
+
+    /**
+     * Flag indicating if customer id sent is the external customer id
+     */
+    const URL_USE_EXTERNAL_ID_TAG = "{USE_EXTERNAL_ID}";
 }

--- a/src/plenigo/internal/ApiURLs.php
+++ b/src/plenigo/internal/ApiURLs.php
@@ -152,7 +152,7 @@ final class ApiURLs
     /**
      * This URL is used to create a login token for an existing user.
      */
-    const USER_MGMT_CREATELOGIN = "/api/v2/externalUser/{USER_ID}/createLoginToken";
+    const USER_MGMT_CREATELOGIN = "/api/v2/externalUser/{USER_ID}/createLoginToken?useExternalCustomerId={USE_EXTERNAL_ID}";
     
     /**
      * This URL is used to assign different customer ids to a plenigo customer.

--- a/src/plenigo/services/UserManagementService.php
+++ b/src/plenigo/services/UserManagementService.php
@@ -163,14 +163,17 @@ class UserManagementService extends Service
      *
      * @param string $customerId Customer id of the user to create login token for
      *
+     * @param bool $useExternalCustomerId Flag indicating if customer id sent is the external customer id
+     *
      * @return string One time token used to create a valid user session
      *
      * @throws PlenigoException In case of communication errors or invalid parameters
      */
-    public static function createLoginToken($customerId)
+    public static function createLoginToken($customerId, $useExternalCustomerId=false)
     {
 
         $url = str_ireplace(ApiParams::URL_USER_ID_TAG, $customerId, ApiURLs::USER_MGMT_CREATELOGIN);
+        $url = str_ireplace(ApiParams::URL_USE_EXTERNAL_ID_TAG, var_export($useExternalCustomerId, true), $url);
 
         $request = static::postRequest($url);
 


### PR DESCRIPTION
Added functionality to use the external customer id when creating a login token.
This is already supported by the REST-API, so no big change.