### PR TITLE
PHPDoc comments updated to match exceptions that are thrown in functions

### DIFF
--- a/src/plenigo/PlenigoManager.php
+++ b/src/plenigo/PlenigoManager.php
@@ -103,7 +103,7 @@ final class PlenigoManager {
      * Singleton instance retrieval method.
      *
      * @return PlenigoManager Singleton instance of {@link plenigo.PlenigoManager}
-     * @throws Exception when the PlenigoManager has not been previously configured.
+     * @throws \Exception when the PlenigoManager has not been previously configured.
      */
     public static function get() {
         if (self::$instance === null) {
@@ -197,7 +197,7 @@ final class PlenigoManager {
      *
      * @param mixed $obj can be an object, a string or any other variable, if its an object, it's class is shown
      * @param string $msg the NOTICE message to send
-     * @param Exception $exc an optional Exception object to show its stacktrace and messages
+     * @param \Exception $exc an optional Exception object to show its stacktrace and messages
      * @return bool returns FALSE only if the object reference or message are NULL
      */
     public static function notice($obj, $msg, $exc = null) {
@@ -213,7 +213,7 @@ final class PlenigoManager {
      *
      * @param mixed $obj can be an object, a string or any other variable, if its an object, it's class is shown
      * @param string $msg the WARNING message to send
-     * @param Exception $exc an optional Exception object to show its stacktrace and messages
+     * @param \Exception $exc an optional Exception object to show its stacktrace and messages
      *
      * @return bool returns FALSE only if the object reference or message are NULL
      */
@@ -230,7 +230,7 @@ final class PlenigoManager {
      *
      * @param mixed $obj can be an object, a string or any other variable, if its an object, it's class is shown
      * @param string $msg the ERROR message to send
-     * @param Exception $exc an optional Exception object to show its stacktrace and messages
+     * @param \Exception $exc an optional Exception object to show its stacktrace and messages
      *
      * @return bool returns FALSE only if the object reference or message are NULL
      */

--- a/src/plenigo/builders/CheckoutSnippetBuilder.php
+++ b/src/plenigo/builders/CheckoutSnippetBuilder.php
@@ -58,7 +58,8 @@ class CheckoutSnippetBuilder {
      * @param string $elementId id of the element the checkout should be inserted into, if this parameter is passed the checkout will be embedded
      * 
      * @return string A Javascript snippet that is compliant with plenigo's Javascript SDK.
-     * @throws \Exception When an error occurs during data encoding
+     * @throws \Exception When the PlenigoManager has not been previously configured.
+     * @throws EncryptionException When an error occurs during data encoding
      */
     public function build($settings = array(), $loginToken = null, $showRegisterFirst = false, $sourceUrl = null, $targetUrl = null, $affiliateId = null, $elementId = null) {
         $clazz = get_class();

--- a/src/plenigo/builders/CheckoutSnippetBuilder.php
+++ b/src/plenigo/builders/CheckoutSnippetBuilder.php
@@ -8,6 +8,7 @@ require_once __DIR__ . '/../internal/utils/EncryptionUtils.php';
 require_once __DIR__ . '/../internal/server-interface/payment/Checkout.php';
 require_once __DIR__ . '/../internal/exceptions/ProductException.php';
 
+use plenigo\internal\exceptions\EncryptionException;
 use plenigo\internal\models\Product;
 use plenigo\internal\serverInterface\payment\Checkout;
 use plenigo\internal\utils\EncryptionUtils;
@@ -57,7 +58,7 @@ class CheckoutSnippetBuilder {
      * @param string $elementId id of the element the checkout should be inserted into, if this parameter is passed the checkout will be embedded
      * 
      * @return string A Javascript snippet that is compliant with plenigo's Javascript SDK.
-     * @throws CryptographyException When an error occurs during data encoding
+     * @throws \Exception When an error occurs during data encoding
      */
     public function build($settings = array(), $loginToken = null, $showRegisterFirst = false, $sourceUrl = null, $targetUrl = null, $affiliateId = null, $elementId = null) {
         $clazz = get_class();
@@ -136,6 +137,7 @@ class CheckoutSnippetBuilder {
      * @param array $settings A map of settings to pass to the Checkout service interface.
      *
      * @return string The encoded data
+     * @throws \Exception
      */
     private function buildCheckoutRequestQueryString($settings = array()) {
         $request = new Checkout($this->product);
@@ -151,6 +153,8 @@ class CheckoutSnippetBuilder {
      * @param string $dataToEncode the string data to encode.
      *
      * @return string The encoded data
+     * @throws \Exception
+     * @throws EncryptionException
      */
     private function buildEncodedData($dataToEncode) {
         $secret = PlenigoManager::get()->getSecret();

--- a/src/plenigo/builders/RegisterSnippetBuilder.php
+++ b/src/plenigo/builders/RegisterSnippetBuilder.php
@@ -55,6 +55,7 @@ class RegisterSnippetBuilder
      *
      * @param bool $wrapWithScriptTag
      * @return string
+     * @throws \Exception
      */
     public function writeOptions($wrapWithScriptTag = true) {
 

--- a/src/plenigo/internal/server-interface/ServerInterface.php
+++ b/src/plenigo/internal/server-interface/ServerInterface.php
@@ -36,6 +36,7 @@ abstract class ServerInterface
      * @param array  $methodArguments The list of arguments passed to the method.
      *
      * @return void
+     * @throws \Exception
      */
     public function __call($methodName, $methodArguments)
     {

--- a/src/plenigo/internal/server-interface/payment/Checkout.php
+++ b/src/plenigo/internal/server-interface/payment/Checkout.php
@@ -71,6 +71,7 @@ final class Checkout extends ServerInterface {
      * 
      * @param mixed $map a map with the checkout information or a Product object
      *
+     * @throws Exception
      * @return Checkout an instance of {@link plenigo\internal\serverInterface\payment\Checkout}
      */
     public function __construct($map = array()) {
@@ -91,6 +92,7 @@ final class Checkout extends ServerInterface {
      * @param AbstractProduct $product The product instance to extract values from.
      *
      * @return void
+     * @throws PlenigoException
      */
     public function setProduct(AbstractProduct $product) {
         $productMap = $product->getMap();
@@ -118,6 +120,7 @@ final class Checkout extends ServerInterface {
      * @param array $map The array to extract values from.
      *
      * @return void
+     * @throws PlenigoException
      */
     public function setValuesFromMap($map) {
         $this->setValueFromMapIfNotEmpty('productId', $map);

--- a/src/plenigo/internal/services/Service.php
+++ b/src/plenigo/internal/services/Service.php
@@ -51,6 +51,7 @@ class Service {
      * @param array  $params   Optional params to pass to the request.
      *
      * @return \plenigo\internal\utils\RestClient request result.
+     * @throws \Exception
      */
     protected static function getRequest($endPoint, $oauth = false, array $params = array()) {
         if ($oauth) {
@@ -73,6 +74,7 @@ class Service {
      * @param array $params Optional params to pass to the request.
      * 
      * @return \plenigo\internal\utils\RestClient request result
+     * @throws \Exception
      */
     protected static function deleteRequest($endPoint, $oauth = false, array $params = array()) {
         if ($oauth) {
@@ -95,6 +97,7 @@ class Service {
      * @param array  $params   Optional params to pass to the request.
      *
      * @return \plenigo\internal\utils\RestClient the request result.
+     * @throws \Exception
      */
     protected static function postRequest($endPoint, $oauth = false, array $params = array()) {
         if ($oauth) {
@@ -117,6 +120,7 @@ class Service {
      * @param array  $params   Optional params to pass to the request.
      *
      * @return \plenigo\internal\utils\RestClient request result.
+     * @throws \Exception
      */
     protected static function postJSONRequest($endPoint, $oauth = false, array $params = array()) {
         if ($oauth) {
@@ -138,6 +142,7 @@ class Service {
      * @param array  $params   Optional params to pass to the request.
      *
      * @return \plenigo\internal\utils\RestClient request result.
+     * @throws \Exception
      */
     protected static function putJSONRequest($endPoint, array $params = array()) {
         $clazz = get_class();
@@ -229,13 +234,13 @@ class Service {
      * 
      * @return mixed The request response or null
      * 
-     * @throws PlenigoException
+     * @throws \Exception
      */
     protected static function executeRequest($pRequest, $pErrorSource, $pErrorMsg) {
         $res = null;
         try {
             $res = $pRequest->execute();
-        } catch (Exception $exc) {
+        } catch (\Exception $exc) {
             $errorCode = ErrorCode::getTranslation($pErrorSource, $exc->getCode());
             if (empty($errorCode) || is_null($errorCode)) {
                 $errorCode = $exc->getCode();
@@ -253,6 +258,7 @@ class Service {
      * and returns the response.
      *
      * @return The request's response.
+     * @throws \Exception
      */
     public function execute() {
         try {

--- a/src/plenigo/internal/utils/CurlRequest.php
+++ b/src/plenigo/internal/utils/CurlRequest.php
@@ -44,6 +44,7 @@ final class CurlRequest {
      *
      * @param string $url The URL where the request should take place.
      *
+     * @throws ConfigException
      * @return void
      */
     public function __construct($url = null) {

--- a/src/plenigo/internal/utils/EncryptionUtils.php
+++ b/src/plenigo/internal/utils/EncryptionUtils.php
@@ -57,7 +57,7 @@ final class EncryptionUtils
      *
      * @return string Encrypted string.
      *
-     * @throws CryptographyException When an error occurs during data encoding
+     * @throws EncryptionException When an error occurs during data encoding
      */
     public static function encryptWithAES($key, $data, $customIV = null)
     {
@@ -87,7 +87,7 @@ final class EncryptionUtils
      * @param string $customIV      [optional]If provided this initialization vector will be used.
      * @return string Decrypted string
      *
-     * @throws CryptographyException When an error occurs during data encoding
+     * @throws EncryptionException When an error occurs during data encoding
      */
     public static function decryptWithAES($key, $encryptedData, $customIV = null)
     {
@@ -165,6 +165,7 @@ final class EncryptionUtils
      * @param string $key The key to prepare.
      *
      * @return string The prepared key.
+     * @throws EncryptionException
      */
     private static function prepareKey($key)
     {
@@ -226,6 +227,7 @@ if (!function_exists('hex2bin')) {
      * @param mixed $data an hexadecimal string presented in pairs of characters
      * @staticvar bool $old a variable to hold if this PHP version is prior to 5.2
      * @return string a string representing the binary data...
+     * @throws EncryptionException
      */
     function hex2bin($data)
     {

--- a/src/plenigo/internal/utils/JWT.php
+++ b/src/plenigo/internal/utils/JWT.php
@@ -64,6 +64,7 @@ class JWT {
      * @return string      A signed JWT
      * @uses jsonEncode
      * @uses urlsafeB64Encode
+     * @throws \Exception
      */
     public static function encode($payload, $key) {
         $header = array('alg' => 'HS256');

--- a/src/plenigo/internal/utils/RestClient.php
+++ b/src/plenigo/internal/utils/RestClient.php
@@ -232,6 +232,7 @@ class RestClient {
      * @param string $url The URL to access.
      *
      * @return CurlRequest instance.
+     * @throws \plenigo\internal\exceptions\ConfigException
      */
     private static function createCurlRequest($url = null) {
         return new CurlRequest($url);

--- a/src/plenigo/services/AccessService.php
+++ b/src/plenigo/services/AccessService.php
@@ -54,7 +54,7 @@ class AccessService extends Service
      * @param string $endTime time when access should end in the format Y-m-d
      * @param array $productIds ids of the products to grant customer access to
      *
-     * @throws PlenigoException
+     * @throws \Exception
      */
     public static function grantUserAccess($customerId, $useExternalCustomerId, $startTime, $endTime, $productIds)
     {
@@ -89,7 +89,7 @@ class AccessService extends Service
      * @param boolean $useExternalCustomerId flag indicating if customer id is an external customer id
      * @param array $productIds ids of the products to grant customer access to
      *
-     * @throws PlenigoException
+     * @throws \Exception
      */
     public static function removeUserAccess($customerId, $useExternalCustomerId, $productIds)
     {

--- a/src/plenigo/services/AppManagementService.php
+++ b/src/plenigo/services/AppManagementService.php
@@ -51,8 +51,8 @@ class AppManagementService extends Service {
      * @param string $description the App Access Description to send to the API
      * 
      * @return AppTokenData the access token to get the App ID
-     * 
-     * @throws PlenigoException
+     *
+     * @throws \Exception
      */
     public static function requestAppToken($customerId, $productId, $description) {
         $testModeText = (PlenigoManager::get()->isTestMode()) ? 'true' : 'false';
@@ -82,7 +82,7 @@ class AppManagementService extends Service {
      * 
      * @return array An array of AppAccessData objects
      * 
-     * @throws PlenigoException
+     * @throws \Exception
      */
     public static function getCustomerApps($customerId) {
         $testModeText = (PlenigoManager::get()->isTestMode()) ? 'true' : 'false';
@@ -111,7 +111,7 @@ class AppManagementService extends Service {
      * 
      * @return AppAccessData the access data with the App ID
      * 
-     * @throws PlenigoException
+     * @throws \Exception
      */
     public static function requestAppId($customerId, $accessToken) {
         $testModeText = (PlenigoManager::get()->isTestMode()) ? 'true' : 'false';
@@ -141,6 +141,7 @@ class AppManagementService extends Service {
      * @param string $appId The App ID to send to the API
      * 
      * @return bool TRUE if the customer can access this product, FALSE otherwise
+     * @throws \Exception
      */
     public static function hasUserBought($customerId, $productId, $appId) {
         $testModeText = (PlenigoManager::get()->isTestMode()) ? 'true' : 'false';
@@ -172,7 +173,7 @@ class AppManagementService extends Service {
      * @param string $customerId he Customer ID to send to the API
      * @param string $appId The App ID to send to the API
      * 
-     * @throws PlenigoException
+     * @throws \Exception
      */
     public static function deleteCustomerApp($customerId, $appId) {
         $testModeText = (PlenigoManager::get()->isTestMode()) ? 'true' : 'false';

--- a/src/plenigo/services/CheckoutService.php
+++ b/src/plenigo/services/CheckoutService.php
@@ -46,6 +46,7 @@ class CheckoutService extends Service {
      * @return boolean TRUE if the Checkout succeeded 
      * 
      * @throws PlenigoException
+     * @throws \Exception
      */
     public static function redeemVoucher($voucherCode = null, $customerId = null, $externalUserId = false) {
         if (is_null($customerId)) {
@@ -107,6 +108,7 @@ class CheckoutService extends Service {
      * @return boolean TRUE if the Checkout succeeded 
      * 
      * @throws PlenigoException
+     * @throws \Exception
      */
     public static function buyFreeProduct($productId = null, $customerId = null, $externalUserId = false) {
         if (is_null($customerId)) {
@@ -164,7 +166,7 @@ class CheckoutService extends Service {
      *
      * @return The request's response.
      *
-     * @throws \plenigo\PlenigoException on request error.
+     * @throws PlenigoException on request error.
      */
     public function execute() {
         try {

--- a/src/plenigo/services/CompanyService.php
+++ b/src/plenigo/services/CompanyService.php
@@ -51,6 +51,7 @@ class CompanyService extends Service {
      * @param int $size Size of the page - must be between 10 and 100
      * 
      * @return CompanyUserList A list of users of the specified company
+     * @throws \Exception
      */
     public static function getUserList($page = 0, $size = 10) {
         $map = array(
@@ -110,6 +111,7 @@ class CompanyService extends Service {
      * @param boolean $useExternalCustomerId (optional) Flag indicating if customer id sent is the external customer id
      *
      * @return CompanyUserList A  list of users of the specified company with the given ids
+     * @throws \Exception
      */
     public static function getUserByIds($userIds = "", $useExternalCustomerId = false) {
 
@@ -143,6 +145,7 @@ class CompanyService extends Service {
      * @param int $size Size of the page - must be between 10 and 100
      * 
      * @return FailedPaymentList A paginated list of FailedPayment objects
+     * @throws \Exception
      */
     public static function getFailedPayments($start = null, $end = null, $status = null, $page = 0, $size = 10) {
         // sanitize dates
@@ -201,6 +204,7 @@ class CompanyService extends Service {
      * @param int $size Size of the page - must be between 10 and 100
      * 
      * @return mixed list of orders
+     * @throws \Exception
      */
     public static function getOrders($start = null, $end = null, $testMode = false , $page = 0, $size = 10) {
         // sanitize dates
@@ -247,6 +251,7 @@ class CompanyService extends Service {
      * @param int $size Size of the page - must be between 10 and 100
      *
      * @return mixed list of subscriptions
+     * @throws \Exception
      */
     public static function getSubscriptions($start = null, $end = null, $testMode = false , $page = 0, $size = 10) {
         // check end date is not in the future

--- a/src/plenigo/services/MeterService.php
+++ b/src/plenigo/services/MeterService.php
@@ -97,6 +97,8 @@ class MeterService extends Service
      * This method parses the metered view data from the user in the cookie.
      *
      * @return MeteredUserData The metered user data
+     * @throws \Exception
+     * @throws \plenigo\internal\exceptions\EncryptionException
      */
 
     private static function getMeteredUserData()
@@ -123,6 +125,8 @@ class MeterService extends Service
      * Returns a flag indicating if the user still has free views left.
      * 
      * @return True if the user still has free views left, false otherwise
+     * @throws \Exception
+     * @throws \plenigo\internal\exceptions\EncryptionException
      */
     public static function hasFreeViews()
     {

--- a/src/plenigo/services/MobileService.php
+++ b/src/plenigo/services/MobileService.php
@@ -50,7 +50,7 @@ class MobileService extends Service {
      * 
      * @return string The Customer ID for that mobile secret
      * 
-     * @throws PlenigoException
+     * @throws \Exception
      */
     public static function verifyMobileSecret($email, $mobileSecret) {
         $map = array(
@@ -80,7 +80,7 @@ class MobileService extends Service {
      * 
      * @param string $customerId The Customer ID
      * @return MobileSecretData the email and secret for the customer mobile
-     * @throws PlenigoException
+     * @throws \Exception
      */
     public static function getMobileSecret($customerId) {
 
@@ -105,7 +105,7 @@ class MobileService extends Service {
      * 
      * @return MobileSecretData the email and secret for the customer mobile
      * 
-     * @throws PlenigoException
+     * @throws \Exception
      */
     public static function createMobileSecret($customerId, $size) {
         $map = array(
@@ -129,7 +129,7 @@ class MobileService extends Service {
      * Deletes a mobile secret for a given Customer ID
      * 
      * @param string $customerId The Customer ID
-     * @throws PlenigoException
+     * @throws \Exception
      */
     public static function deleteMobileSecret($customerId) {
         $url = str_ireplace(ApiParams::URL_USER_ID_TAG, $customerId, ApiURLs::MOBILE_SECRET_URL);

--- a/src/plenigo/services/ProductService.php
+++ b/src/plenigo/services/ProductService.php
@@ -48,7 +48,7 @@ class ProductService extends Service {
      *
      * @param string $productId The product id to use.
      * @return ProductData the product data related to the access token
-     * @throws PlenigoException whenever an error happens
+     * @throws \Exception whenever an error happens
      */
     public static function getProductData($productId) {
         $clazz = get_class();
@@ -103,7 +103,7 @@ class ProductService extends Service {
      *
      * @return array an asociative array as a ResultSet with totalElements, page size, last id and the list of products
      *
-     * @throws PlenigoException
+     * @throws \Exception
      */
     public static function getProductList($pageSize = 10, $page = 0) {
         return self::getProductListFromServer($pageSize, $page, ApiURLs::LIST_PRODUCTS);
@@ -118,7 +118,7 @@ class ProductService extends Service {
      *
      * @return array an asociative array as a ResultSet with totalElements, page size, last id and the list of products
      *
-     * @throws PlenigoException
+     * @throws \Exception
      */
     private static final function getProductListFromServer($pageSize, $page, $url) {
         $clazz = get_class();
@@ -162,7 +162,7 @@ class ProductService extends Service {
      *
      * @return array an asociative array as a ResultSet with totalElements, page size, last id and the list of products
      *
-     * @throws PlenigoException
+     * @throws \Exception
      */
     public static function getProductListWithDetails($pageSize = 10, $page = 0) {
         return self::getProductListFromServer($pageSize, $page, ApiURLs::LIST_PRODUCTS_FULL_DETAILS);
@@ -176,7 +176,7 @@ class ProductService extends Service {
      *
      * @return CategoryData
      *
-     * @throws PlenigoException whenever an error happens
+     * @throws \Exception whenever an error happens
      */
     public static function getCategoryData($categoryId) {
         $clazz = get_class();
@@ -232,7 +232,7 @@ class ProductService extends Service {
      *
      * @return array an asociative array as a ResultSet with totalElements, page size, last id and the list of products
      *
-     * @throws PlenigoException
+     * @throws \Exception
      */
     public static function getCategoryList($pageSize = 10, $page = 0) {
         $clazz = get_class();
@@ -290,7 +290,7 @@ class ProductService extends Service {
      * This method can't actually throw aan Exception because it will be called from inside a catch
      * block and the Exception would be occluded by a run-time error.
      *
-     * @param Exception $exc the previous exception thrown
+     * @param \Exception $exc the previous exception thrown
      * @param int $errorCode the error code for the exception
      * @param string $defaultMsg the error message for default error
      * @return PlenigoException the exception that needs to be thrown

--- a/src/plenigo/services/TransactionService.php
+++ b/src/plenigo/services/TransactionService.php
@@ -47,6 +47,7 @@ class TransactionService extends Service {
      * @param string $payMethod Payment method used to pay the transaction. See PaymentMethod class
      * @param string $txStatus Status of the transaction. See TransactionStatus class
      * @return TransactionList A list of transactions of the specified company
+     * @throws \Exception
      */
     public static function searchTransactions($page = 0, $size = 10, $startDate = null, $endDate = null, $payMethod = null, $txStatus = null) {
 

--- a/src/plenigo/services/UserManagementService.php
+++ b/src/plenigo/services/UserManagementService.php
@@ -202,7 +202,7 @@ class UserManagementService extends Service
      *
      * @return boolean TRUE if the transaction was successful
      *
-     * @throws \Exception
+     * @throws \Exception In case of communication errors or invalid parameters
      */
     public static function importCustomerAccess($customerId, $isExternal = false, $customIds = array())
     {

--- a/src/plenigo/services/UserManagementService.php
+++ b/src/plenigo/services/UserManagementService.php
@@ -55,7 +55,7 @@ class UserManagementService extends Service
      *
      * @return string Id of the created customer.
      *
-     * @throws PlenigoException In case of communication errors or invalid parameters.
+     * @throws \Exception In case of communication errors or invalid parameters.
      */
     public static function registerUser($email, $language = "en", $externalUserId = null, $firstName = null, $name = null, $withPasswordReset = false)
     {
@@ -108,7 +108,7 @@ class UserManagementService extends Service
      *
      * @return bool TRUE Email address changed
      *
-     * @throws PlenigoException In case of communication errors or invalid parameters
+     * @throws \Exception In case of communication errors or invalid parameters
      */
     public static function changeEmail($customerId, $email, $useExternalCustomerId = false)
     {
@@ -143,7 +143,7 @@ class UserManagementService extends Service
      *
      * @return bool TRUE external customer id added
      *
-     * @throws PlenigoException In case of communication errors or invalid parameters
+     * @throws \Exception In case of communication errors or invalid parameters
      */
     public static function addExternalCustomerId($customerId, $externalCustomerId)
     {
@@ -170,7 +170,7 @@ class UserManagementService extends Service
      *
      * @return string One time token used to create a valid user session
      *
-     * @throws PlenigoException In case of communication errors or invalid parameters
+     * @throws \Exception In case of communication errors or invalid parameters
      */
     public static function createLoginToken($customerId, $useExternalCustomerId = false)
     {
@@ -202,7 +202,7 @@ class UserManagementService extends Service
      *
      * @return boolean TRUE if the transaction was successful
      *
-     * @throws PlenigoException In case of communication errors or invalid parameters
+     * @throws \Exception
      */
     public static function importCustomerAccess($customerId, $isExternal = false, $customIds = array())
     {

--- a/src/plenigo/services/UserService.php
+++ b/src/plenigo/services/UserService.php
@@ -110,6 +110,8 @@ class UserService extends Service
      * @param string $error (optional) error message
      *
      * @return array|boolean user data or boolean false
+     * @throws PlenigoException
+     * @throws \Exception
      */
     public static function verifyLogin($email, $password, $data = array(), &$error = '') {
 
@@ -195,6 +197,7 @@ class UserService extends Service
      * @return bool TRUE if the user in the cookie has bought the product and the session is not expired, false otherwise
      *
      * @throws \plenigo\PlenigoException whenever an error happens
+     * @throws \Exception
      */
     public static function hasUserBought($productId, $customerId = null, $useExternalCustomerId = false)
     {
@@ -259,6 +262,7 @@ class UserService extends Service
      * @return array
      *
      * @throws \plenigo\PlenigoException whenever an error happens
+     * @throws \Exception
      */
     public static function hasBoughtProductWithProducts($productId, $customerId = null, $useExternalCustomerId = false)
     {
@@ -316,6 +320,8 @@ class UserService extends Service
      * all product paywall should be disabled and access should be granted
      *
      * @return bool true if Paywall is enabled and we need to check for specific product buy information
+     * @throws PlenigoException
+     * @throws \Exception
      */
     public static function isPaywallEnabled()
     {
@@ -344,6 +350,8 @@ class UserService extends Service
      * Check if the user has been logged in (cookie is found and valid)
      *
      * @return bool TRUE if the user has been logged in
+     * @throws \Exception
+     * @throws \plenigo\internal\exceptions\EncryptionException
      */
     public static function isLoggedIn()
     {
@@ -360,7 +368,8 @@ class UserService extends Service
      * Retrieves the user info from the cookie.
      * @param string $pCustId The customer ID if its not logged in
      * @return Customer The Customer Information from the cookie
-     * @throws \plenigo\PlenigoException whenever an error happens
+     * @throws \Exception whenever an error happens
+     * @throws \plenigo\internal\exceptions\EncryptionException
      */
     public static function getCustomerInfo($pCustId = null)
     {
@@ -456,6 +465,7 @@ class UserService extends Service
      * @param boolean $useExternalCustomerId (optional) Flag indicating if customer id sent is the external customer id
      * @return array The associative array containing the bought products/subscriptions or an empty array
      * @throws PlenigoException If the compay ID and/or the Secret key is rejected
+     * @throws \Exception
      */
     public static function getProductsBought($pCustId = null, $useExternalCustomerId = false)
     {

--- a/src/plenigo/services/VoucherService.php
+++ b/src/plenigo/services/VoucherService.php
@@ -46,6 +46,7 @@ class VoucherService extends Service {
      * @return CampaignResponse the campaign 
      * 
      * @throws PlenigoException
+     * @throws \Exception
      */
     public static function generateCampaign($name = null, $productId = null, $startDate = null, $expirationDate = null, $type = 'SINGLE', $amount = 1, $channels = array()) {
         if (is_null($productId)) {


### PR DESCRIPTION
I changed the PHPDoc comments of some functions in a way that the @throw tags match the exceptions that can be actually throw in the function. I stumbled over it because my IDE complained about that.